### PR TITLE
Reinitialize modules from .NET Core 3.1 to .NET 5

### DIFF
--- a/NemzetiVirusbolt/NemzetiVirusbolt.API/Controllers/ProductsController.cs
+++ b/NemzetiVirusbolt/NemzetiVirusbolt.API/Controllers/ProductsController.cs
@@ -3,12 +3,12 @@ using Microsoft.AspNetCore.Mvc;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using AutoMapper;
-using NemzetiVirusbolt.API.Resources;
 using NemzetiVirusbolt.Core;
 using NemzetiVirusbolt.Core.Models;
 using NemzetiVirusbolt.Core.Repositories;
+using NemzetiVirusbolt.Api.Resources;
 
-namespace NemzetiVirusbolt.API.Controllers
+namespace NemzetiVirusbolt.Api.Controllers
 {
     [Route("api/[controller]")]
     [ApiController]

--- a/NemzetiVirusbolt/NemzetiVirusbolt.API/Controllers/StocksController.cs
+++ b/NemzetiVirusbolt/NemzetiVirusbolt.API/Controllers/StocksController.cs
@@ -3,12 +3,12 @@ using System.Collections.Generic;
 using Microsoft.AspNetCore.Mvc;
 using System.Threading.Tasks;
 using AutoMapper;
-using NemzetiVirusbolt.API.Resources;
 using NemzetiVirusbolt.Core;
 using NemzetiVirusbolt.Core.Models;
 using NemzetiVirusbolt.Core.Repositories;
+using NemzetiVirusbolt.Api.Resources;
 
-namespace NemzetiVirusbolt.API.Controllers
+namespace NemzetiVirusbolt.Api.Controllers
 {
     [Route("api/[controller]")]
     [ApiController]

--- a/NemzetiVirusbolt/NemzetiVirusbolt.API/Controllers/SuppliersController.cs
+++ b/NemzetiVirusbolt/NemzetiVirusbolt.API/Controllers/SuppliersController.cs
@@ -2,11 +2,11 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using AutoMapper;
-using NemzetiVirusbolt.API.Resources;
 using NemzetiVirusbolt.Core.Models;
 using NemzetiVirusbolt.Core.Repositories;
+using NemzetiVirusbolt.Api.Resources;
 
-namespace NemzetiVirusbolt.API.Controllers
+namespace NemzetiVirusbolt.Api.Controllers
 {
     [Route("api/[controller]")]
     [ApiController]

--- a/NemzetiVirusbolt/NemzetiVirusbolt.API/Mapping/MappingProfile.cs
+++ b/NemzetiVirusbolt/NemzetiVirusbolt.API/Mapping/MappingProfile.cs
@@ -1,8 +1,8 @@
 ﻿using AutoMapper;
-using NemzetiVirusbolt.API.Resources;
+using NemzetiVirusbolt.Api.Resources;
 using NemzetiVirusbolt.Core.Models;
 
-namespace NemzetiVirusbolt.API.Mapping
+namespace NemzetiVirusbolt.Api.Mapping
 {
     public class MappingProfile : Profile
     {

--- a/NemzetiVirusbolt/NemzetiVirusbolt.API/NemzetiVirusbolt.API.csproj
+++ b/NemzetiVirusbolt/NemzetiVirusbolt.API/NemzetiVirusbolt.API.csproj
@@ -1,10 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="5.6.3" />
     <PackageReference Include="AutoMapper" Version="8.0.0" />
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="1.2.0" />
     <PackageReference Include="MySql.Data.EntityFrameworkCore" Version="8.0.22" />

--- a/NemzetiVirusbolt/NemzetiVirusbolt.API/Persistence/ApplicationDbContext.cs
+++ b/NemzetiVirusbolt/NemzetiVirusbolt.API/Persistence/ApplicationDbContext.cs
@@ -1,7 +1,7 @@
 ﻿using Microsoft.EntityFrameworkCore;
 using NemzetiVirusbolt.Core.Models;
 
-namespace NemzetiVirusbolt.API.Persistence
+namespace NemzetiVirusbolt.Api.Persistence
 {
     public class ApplicationDbContext : DbContext
     {

--- a/NemzetiVirusbolt/NemzetiVirusbolt.API/Persistence/Repositories/ProductRepository.cs
+++ b/NemzetiVirusbolt/NemzetiVirusbolt.API/Persistence/Repositories/ProductRepository.cs
@@ -5,7 +5,7 @@ using Microsoft.EntityFrameworkCore;
 using NemzetiVirusbolt.Core.Models;
 using NemzetiVirusbolt.Core.Repositories;
 
-namespace NemzetiVirusbolt.API.Persistence.Repositories
+namespace NemzetiVirusbolt.Api.Persistence.Repositories
 {
     public class ProductRepository : IProductRepository
     {

--- a/NemzetiVirusbolt/NemzetiVirusbolt.API/Persistence/Repositories/StockRepository.cs
+++ b/NemzetiVirusbolt/NemzetiVirusbolt.API/Persistence/Repositories/StockRepository.cs
@@ -5,7 +5,7 @@ using Microsoft.EntityFrameworkCore;
 using NemzetiVirusbolt.Core.Models;
 using NemzetiVirusbolt.Core.Repositories;
 
-namespace NemzetiVirusbolt.API.Persistence.Repositories
+namespace NemzetiVirusbolt.Api.Persistence.Repositories
 {
     public class StockRepository : IStockRepository
     {

--- a/NemzetiVirusbolt/NemzetiVirusbolt.API/Persistence/Repositories/SupplierRepository.cs
+++ b/NemzetiVirusbolt/NemzetiVirusbolt.API/Persistence/Repositories/SupplierRepository.cs
@@ -4,7 +4,7 @@ using Microsoft.EntityFrameworkCore;
 using NemzetiVirusbolt.Core.Models;
 using NemzetiVirusbolt.Core.Repositories;
 
-namespace NemzetiVirusbolt.API.Persistence.Repositories
+namespace NemzetiVirusbolt.Api.Persistence.Repositories
 {
     public class SupplierRepository : ISupplierRepository
     {

--- a/NemzetiVirusbolt/NemzetiVirusbolt.API/Persistence/UnitOfWork.cs
+++ b/NemzetiVirusbolt/NemzetiVirusbolt.API/Persistence/UnitOfWork.cs
@@ -1,7 +1,7 @@
 ﻿using System.Threading.Tasks;
 using NemzetiVirusbolt.Core;
 
-namespace NemzetiVirusbolt.API.Persistence
+namespace NemzetiVirusbolt.Api.Persistence
 {
     public class UnitOfWork : IUnitOfWork
     {

--- a/NemzetiVirusbolt/NemzetiVirusbolt.API/Program.cs
+++ b/NemzetiVirusbolt/NemzetiVirusbolt.API/Program.cs
@@ -1,7 +1,7 @@
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Hosting;
 
-namespace NemzetiVirusbolt.API
+namespace NemzetiVirusbolt.Api
 {
     public class Program
     {

--- a/NemzetiVirusbolt/NemzetiVirusbolt.API/Properties/launchSettings.json
+++ b/NemzetiVirusbolt/NemzetiVirusbolt.API/Properties/launchSettings.json
@@ -4,23 +4,24 @@
     "windowsAuthentication": false,
     "anonymousAuthentication": true,
     "iisExpress": {
-      "applicationUrl": "http://localhost:61351",
-      "sslPort": 44399
+      "applicationUrl": "http://localhost:26262",
+      "sslPort": 44338
     }
   },
   "profiles": {
     "IIS Express": {
       "commandName": "IISExpress",
       "launchBrowser": true,
-      "launchUrl": "api/suppliers",
+      "launchUrl": "swagger",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
     },
-    "NemzetiVirusbolt.API": {
+    "NemzetiVirusbolt.Api": {
       "commandName": "Project",
+      "dotnetRunMessages": "true",
       "launchBrowser": true,
-      "launchUrl": "api/suppliers",
+      "launchUrl": "swagger",
       "applicationUrl": "https://localhost:5001;http://localhost:5000",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"

--- a/NemzetiVirusbolt/NemzetiVirusbolt.API/Resources/GetMergedStockResource.cs
+++ b/NemzetiVirusbolt/NemzetiVirusbolt.API/Resources/GetMergedStockResource.cs
@@ -1,4 +1,4 @@
-﻿namespace NemzetiVirusbolt.API.Resources
+﻿namespace NemzetiVirusbolt.Api.Resources
 {
     public class GetMergedStockResource
     {

--- a/NemzetiVirusbolt/NemzetiVirusbolt.API/Resources/GetProductResource.cs
+++ b/NemzetiVirusbolt/NemzetiVirusbolt.API/Resources/GetProductResource.cs
@@ -1,4 +1,4 @@
-﻿namespace NemzetiVirusbolt.API.Resources
+﻿namespace NemzetiVirusbolt.Api.Resources
 {
     public class GetProductResource
     {

--- a/NemzetiVirusbolt/NemzetiVirusbolt.API/Resources/GetStockResource.cs
+++ b/NemzetiVirusbolt/NemzetiVirusbolt.API/Resources/GetStockResource.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace NemzetiVirusbolt.API.Resources
+namespace NemzetiVirusbolt.Api.Resources
 {
     public class GetStockResource
     {

--- a/NemzetiVirusbolt/NemzetiVirusbolt.API/Resources/GetStockTotalValueResource.cs
+++ b/NemzetiVirusbolt/NemzetiVirusbolt.API/Resources/GetStockTotalValueResource.cs
@@ -1,4 +1,4 @@
-﻿namespace NemzetiVirusbolt.API.Resources
+﻿namespace NemzetiVirusbolt.Api.Resources
 {
     public class GetStockTotalValueResource
     {

--- a/NemzetiVirusbolt/NemzetiVirusbolt.API/Resources/GetSupplierResource.cs
+++ b/NemzetiVirusbolt/NemzetiVirusbolt.API/Resources/GetSupplierResource.cs
@@ -1,4 +1,4 @@
-﻿namespace NemzetiVirusbolt.API.Resources
+﻿namespace NemzetiVirusbolt.Api.Resources
 {
     public class GetSupplierResource
     {

--- a/NemzetiVirusbolt/NemzetiVirusbolt.API/Resources/SaveProductResource.cs
+++ b/NemzetiVirusbolt/NemzetiVirusbolt.API/Resources/SaveProductResource.cs
@@ -1,4 +1,4 @@
-﻿namespace NemzetiVirusbolt.API.Resources
+﻿namespace NemzetiVirusbolt.Api.Resources
 {
     public class SaveProductResource
     {

--- a/NemzetiVirusbolt/NemzetiVirusbolt.API/Resources/SaveStockResource.cs
+++ b/NemzetiVirusbolt/NemzetiVirusbolt.API/Resources/SaveStockResource.cs
@@ -1,4 +1,4 @@
-﻿namespace NemzetiVirusbolt.API.Resources
+﻿namespace NemzetiVirusbolt.Api.Resources
 {
     public class SaveStockResource
     {

--- a/NemzetiVirusbolt/NemzetiVirusbolt.API/Startup.cs
+++ b/NemzetiVirusbolt/NemzetiVirusbolt.API/Startup.cs
@@ -5,12 +5,13 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using NemzetiVirusbolt.API.Persistence;
-using NemzetiVirusbolt.API.Persistence.Repositories;
+using Microsoft.OpenApi.Models;
+using NemzetiVirusbolt.Api.Persistence;
+using NemzetiVirusbolt.Api.Persistence.Repositories;
 using NemzetiVirusbolt.Core;
 using NemzetiVirusbolt.Core.Repositories;
 
-namespace NemzetiVirusbolt.API
+namespace NemzetiVirusbolt.Api
 {
     public class Startup
     {
@@ -36,13 +37,21 @@ namespace NemzetiVirusbolt.API
             services.AddScoped<IUnitOfWork, UnitOfWork>();
 
             services.AddControllers();
+            services.AddSwaggerGen(c =>
+            {
+                c.SwaggerDoc("v1", new OpenApiInfo { Title = "NemzetiVirusbolt.Api", Version = "v1" });
+            });
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         {
             if (env.IsDevelopment())
+            {
                 app.UseDeveloperExceptionPage();
+                app.UseSwagger();
+                app.UseSwaggerUI(c => c.SwaggerEndpoint("/swagger/v1/swagger.json", "NemzetiVirusbolt.Api v1"));
+            }
 
             app.UseHttpsRedirection();
 

--- a/NemzetiVirusbolt/NemzetiVirusbolt.sln
+++ b/NemzetiVirusbolt/NemzetiVirusbolt.sln
@@ -1,13 +1,11 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.30413.136
+# Visual Studio Version 17
+VisualStudioVersion = 17.1.32414.318
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NemzetiVirusbolt.Core", "NemzetiVirusbolt.Core\NemzetiVirusbolt.Core.csproj", "{FC9CB246-6409-4DB7-9FFA-A2E6689E1234}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NemzetiVirusbolt.Desktop", "NemzetiVirusbolt.Desktop\NemzetiVirusbolt.Desktop.csproj", "{27DEA75D-B9B7-46E9-80EC-EFA7CC5721BC}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NemzetiVirusbolt.API", "NemzetiVirusbolt.API\NemzetiVirusbolt.API.csproj", "{3557D12B-7182-4488-908C-6E3FBF792553}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NemzetiVirusbolt.Validation", "NemzetiVirusbolt.Validation\NemzetiVirusbolt.Validation.csproj", "{7F341656-45CA-4B8C-94BE-C2123588A723}"
 EndProject
@@ -15,7 +13,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NemzetiVirusbolt.Desktop.Dt
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NemzetiVirusbolt.ValidationTests", "NemzetiVirusbolt.ValidationTests\NemzetiVirusbolt.ValidationTests.csproj", "{8D4FD7AF-98F5-49D7-B5B9-0D2717F197BF}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NemzetiVirusbolt.Desktop.Services", "NemzetiVirusbolt.Desktop.Services\NemzetiVirusbolt.Desktop.Services.csproj", "{94E10EA8-0C73-497B-A69D-DBA556C0E1B4}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NemzetiVirusbolt.Desktop.Services", "NemzetiVirusbolt.Desktop.Services\NemzetiVirusbolt.Desktop.Services.csproj", "{94E10EA8-0C73-497B-A69D-DBA556C0E1B4}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NemzetiVirusbolt.Api", "NemzetiVirusbolt.Api\NemzetiVirusbolt.Api.csproj", "{95859D53-4EF8-49F8-9426-2ACDBB16D305}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -31,10 +31,6 @@ Global
 		{27DEA75D-B9B7-46E9-80EC-EFA7CC5721BC}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{27DEA75D-B9B7-46E9-80EC-EFA7CC5721BC}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{27DEA75D-B9B7-46E9-80EC-EFA7CC5721BC}.Release|Any CPU.Build.0 = Release|Any CPU
-		{3557D12B-7182-4488-908C-6E3FBF792553}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{3557D12B-7182-4488-908C-6E3FBF792553}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{3557D12B-7182-4488-908C-6E3FBF792553}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{3557D12B-7182-4488-908C-6E3FBF792553}.Release|Any CPU.Build.0 = Release|Any CPU
 		{7F341656-45CA-4B8C-94BE-C2123588A723}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{7F341656-45CA-4B8C-94BE-C2123588A723}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7F341656-45CA-4B8C-94BE-C2123588A723}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -51,6 +47,10 @@ Global
 		{94E10EA8-0C73-497B-A69D-DBA556C0E1B4}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{94E10EA8-0C73-497B-A69D-DBA556C0E1B4}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{94E10EA8-0C73-497B-A69D-DBA556C0E1B4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{95859D53-4EF8-49F8-9426-2ACDBB16D305}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{95859D53-4EF8-49F8-9426-2ACDBB16D305}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{95859D53-4EF8-49F8-9426-2ACDBB16D305}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{95859D53-4EF8-49F8-9426-2ACDBB16D305}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
### :pencil2: Description

- Reinitializing all the executable project types from `.NET Core 3.1` to `.NET 5`.
